### PR TITLE
Support ECDSA Certificate Authorities

### DIFF
--- a/src/OID.php
+++ b/src/OID.php
@@ -39,6 +39,13 @@ class OID
 					default:
 						return false;
 				}
+			case OPENSSL_KEYTYPE_EC:
+				switch($digest) {
+					case OPENSSL_ALGO_SHA1:
+						return self::getOIDFromName('ecdsa-with-SHA1');
+					default:
+						return false;
+				}
 			case OPENSSL_KEYTYPE_DSA:
 				switch($digest) {
 					case OPENSSL_ALGO_SHA1:
@@ -100,6 +107,11 @@ class OID
 		"1.2.840.113549.1.1.3" => "md4withRSAEncryption",
 		"1.2.840.113549.1.1.4" => "md5withRSAEncryption",
 		"1.2.840.113549.1.1.5" => "sha1withRSAEncryption",
+		//ec
+		"1.2.840.10045.4.1" => "ecdsa-with-SHA1",
+		"1.2.840.10045.4.3.2" => "ecdsa-with-sha256",
+		"1.2.840.10045.4.3.3" => "ecdsa-with-sha384",
+		"1.2.840.10045.4.3.4" => "ecdsa-with-sha512",
 		//Diffie-Hellman
 		"1.2.840.10046.2.1" => "dhPublicNumber",
 		

--- a/src/X509_CRL.php
+++ b/src/X509_CRL.php
@@ -72,8 +72,6 @@ class X509_CRL
 		if($ca_pkey_details === false)
 			return false;
 		$ca_pkey_type = $ca_pkey_details['type'];
-		if($ca_pkey_type == OPENSSL_KEYTYPE_EC || $ca_pkey_type == -1)
-			return false;
 		if(!in_array($ca_pkey_type, $algs_cipher))
 			return false;
 		


### PR DESCRIPTION
PHP 7.1 and later includes support for ECDSA with OpenSSL. Only a few small changes to this code are required to support ECDSA CRLs.

With this patch applied, I can generate a CRL using an ECDSA CA:
```
$ openssl crl -CAfile CurveCA.crt -noout -in Curve+CRL.crl 
verify OK
$ openssl crl -text -noout -in Curve+CRL.crl 
Certificate Revocation List (CRL):
        Version 2 (0x1)
        Signature Algorithm: ecdsa-with-SHA1
        Issuer: /CN=curveca
        Last Update: Nov 25 15:49:31 2019 GMT
        Next Update: Apr 11 15:49:31 2047 GMT
        CRL extensions:
            X509v3 Authority Key Identifier: 
                keyid:03:DF:49:C8:A7:EC:0F:5F:03:B7:65:CE:36:08:AB:D9:B4:32:F4:66
                DirName:/CN=curveca
                serial:00

            X509v3 CRL Number: 
                10003
Revoked Certificates:
    Serial Number: 7928A10E10CF1647
        Revocation Date: Nov 25 15:27:13 2019 GMT
        CRL entry extensions:
            X509v3 CRL Reason Code: 
                Key Compromise
    Signature Algorithm: ecdsa-with-SHA1
        30:43:02:1f:50:3f:32:8f:5d:f0:bd:e1:a2:57:bd:be:19:b7:
        17:7f:24:c8:61:0f:09:e4:d2:af:72:91:49:8f:b3:a4:7b:02:
        20:54:d4:ac:64:1a:73:27:bd:a6:35:47:81:53:ab:b0:6d:0c:
        9f:e9:6e:f9:b7:4d:8f:60:37:88:26:54:8d:d9:e5
```